### PR TITLE
Fix app localization language metadata

### DIFF
--- a/HagimiMonitor/Localizable.xcstrings
+++ b/HagimiMonitor/Localizable.xcstrings
@@ -1757,7 +1757,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": ""
+            "value": "display"
           }
         }
       }

--- a/hagimi-monitor.xcodeproj/project.pbxproj
+++ b/hagimi-monitor.xcodeproj/project.pbxproj
@@ -458,6 +458,10 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleLocalizations = (
+					en,
+					"zh-Hans",
+				);
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -492,6 +496,10 @@
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_CFBundleLocalizations = (
+					en,
+					"zh-Hans",
+				);
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -526,6 +534,10 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = HagimiMonitor;
+				INFOPLIST_KEY_CFBundleLocalizations = (
+					en,
+					"zh-Hans",
+				);
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -572,6 +584,10 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = HagimiMonitor;
+				INFOPLIST_KEY_CFBundleLocalizations = (
+					en,
+					"zh-Hans",
+				);
 				INFOPLIST_KEY_CFBundleShortVersionString = "$(MARKETING_VERSION)";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";


### PR DESCRIPTION
Fixes #7 

## Summary

This PR fixes the app localization metadata so macOS can recognize the supported app languages.

The project already contains English translations in `Localizable.xcstrings`, but the app can still remain in Chinese even when English is selected as the system/app language. This change explicitly declares the supported localizations in the generated Info.plist settings.

## Changes

- Add `CFBundleLocalizations` with:
  - `en`
  - `zh-Hans`
- Apply the localization metadata to both app targets/build configurations
- Fill one missing English string catalog value:
  - empty value → `display`

## Motivation

Before adding more languages, the existing Chinese/English localization should work correctly at runtime.

Without proper bundle localization metadata, macOS may not treat the app as supporting English even though English strings exist in `Localizable.xcstrings`.

## Testing

Please verify the following manually:

- Set macOS system language to English
- Or set HagimiMonitor's app-specific language to English
- Quit and relaunch HagimiMonitor
- Confirm that the menu bar panel and settings UI use English strings
- Switch back to Chinese and confirm Chinese strings still work

## Notes

This PR only fixes the existing localization metadata and does not add a new language.

Japanese localization is planned as a follow-up PR after this base i18n behavior is fixed.