### PR TITLE
修复监控类别本地化回退逻辑

### DIFF
--- a/HagimiMonitor/MonitorModels.swift
+++ b/HagimiMonitor/MonitorModels.swift
@@ -56,19 +56,25 @@ enum MonitorKind: String, CaseIterable, Identifiable {
     var id: String { rawValue }
 
     var title: String {
+        let key = "kind.\(rawValue)"
+        let localized = String(localized: String.LocalizationValue(key))
+        return localized == key ? fallbackTitle : localized
+    }
+
+    private var fallbackTitle: String {
         switch self {
         case .cpu:
-            String(localized: "kind.cpu")
+            "CPU"
         case .gpu:
-            String(localized: "kind.gpu")
+            "GPU"
         case .memory:
-            String(localized: "kind.memory")
+            "Memory"
         case .storage:
-            String(localized: "kind.storage")
+            "Storage"
         case .network:
-            String(localized: "kind.network")
+            "Network"
         case .battery:
-            String(localized: "kind.battery")
+            "Power"
         }
     }
 

--- a/HagimiMonitor/MonitorModels.swift
+++ b/HagimiMonitor/MonitorModels.swift
@@ -157,6 +157,7 @@ struct MonitorMetric: Identifiable {
 struct MonitorModule: Identifiable {
     let kind: MonitorKind
     var context: String? = nil
+    var componentName: String? = nil
     var value: Double
     var summary: String
     var metrics: [MonitorMetric]

--- a/HagimiMonitor/MonitorPanelView.swift
+++ b/HagimiMonitor/MonitorPanelView.swift
@@ -229,7 +229,7 @@ private struct MetricGlassRow: View {
                     .foregroundStyle(tint)
                     .frame(width: 18)
 
-                Text("\(module.kind.title):")
+                Text(module.kind.title + ":")
                     .monitorPanelMetricLabelFont()
                     .foregroundStyle(theme.primaryText)
                     .lineLimit(1)

--- a/HagimiMonitor/MonitorPanelView.swift
+++ b/HagimiMonitor/MonitorPanelView.swift
@@ -229,15 +229,26 @@ private struct MetricGlassRow: View {
                     .foregroundStyle(tint)
                     .frame(width: 18)
 
-                Text(module.kind.title + ":")
-                    .monitorPanelMetricLabelFont()
-                    .foregroundStyle(theme.primaryText)
-                    .lineLimit(1)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(module.kind.title + ":")
+                        .monitorPanelMetricLabelFont()
+                        .foregroundStyle(theme.primaryText)
+                        .lineLimit(1)
+
+                    if let componentName = module.componentName {
+                        Text(componentName)
+                            .monitorPanelCaptionFont(.caption2)
+                            .foregroundStyle(theme.captionText)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
+                }
 
                 Text(detail)
                     .monitorPanelMonoFont(weight: .semibold)
                     .foregroundStyle(theme.valueText)
                     .lineLimit(1)
+                    .layoutPriority(2)
 
                 Spacer(minLength: 8)
 

--- a/HagimiMonitor/Samplers/CPUSampler.swift
+++ b/HagimiMonitor/Samplers/CPUSampler.swift
@@ -8,6 +8,7 @@ import IOKit
 final class CPUSampler: MonitorSampler {
     var kind: MonitorKind { .cpu }
 
+    private let componentName = CPUSampler.cpuBrandName()
     private var previousCPUInfo: host_cpu_load_info?
     #if DISPLAY_CONTROL
     private let smcReader: SMCReader? = SMCReader()
@@ -64,11 +65,16 @@ final class CPUSampler: MonitorSampler {
 
         return MonitorModule(
             kind: .cpu,
+            componentName: componentName,
             value: total,
             summary: percent(total),
             metrics: resultMetrics,
             samples: seedSamples(total)
         )
+    }
+
+    private static func cpuBrandName() -> String? {
+        sysctlString("machdep.cpu.brand_string") ?? sysctlString("hw.model")
     }
 
     private func hostCPULoadInfo() -> host_cpu_load_info? {
@@ -106,4 +112,19 @@ final class CPUSampler: MonitorSampler {
 
         return Date(timeIntervalSince1970: TimeInterval(bootTime.tv_sec) + TimeInterval(bootTime.tv_usec) / 1_000_000)
     }
+}
+
+private func sysctlString(_ name: String) -> String? {
+    var size = 0
+    guard sysctlbyname(name, nil, &size, nil, 0) == 0, size > 0 else {
+        return nil
+    }
+
+    var buffer = [CChar](repeating: 0, count: size)
+    guard sysctlbyname(name, &buffer, &size, nil, 0) == 0 else {
+        return nil
+    }
+
+    let value = String(cString: buffer).trimmingCharacters(in: .whitespacesAndNewlines)
+    return value.isEmpty ? nil : value
 }

--- a/HagimiMonitor/Samplers/GPUSampler.swift
+++ b/HagimiMonitor/Samplers/GPUSampler.swift
@@ -28,11 +28,25 @@ final class GPUSampler: MonitorSampler {
 
         return MonitorModule(
             kind: .gpu,
+            componentName: componentName(from: reading.model),
             value: utilization,
             summary: percent(utilization),
             metrics: metrics,
             samples: seedSamples(utilization)
         )
+    }
+
+    private func componentName(from model: String) -> String? {
+        let cleaned = model
+            .trimmingCharacters(in: .controlCharacters.union(.whitespacesAndNewlines))
+            .replacingOccurrences(of: "\0", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !cleaned.isEmpty, cleaned != "GPU" else {
+            return nil
+        }
+
+        return cleaned
     }
 
     private func gpuReading() -> GPUReading? {
@@ -59,9 +73,7 @@ final class GPUSampler: MonitorSampler {
             let tiler = doubleValue(stats["Tiler Utilization %"])
             let usedMemory = doubleValue(stats["In use system memory"])
             let allocatedMemory = doubleValue(stats["Alloc system memory"])
-            let model = registryStringValue(accelerator, "model")
-                ?? registryStringValue(accelerator, "IOClass")
-                ?? "GPU"
+            let model = registryStringValue(accelerator, "model") ?? "GPU"
 
             let reading = GPUReading(
                 model: model,


### PR DESCRIPTION
当本地化查找返回原始 key 时，为监控类别提供默认标题。
面板行标签改用普通字符串拼接，避免显示 kind.* key。
避免出现如下图所示情况（在英文系统下会出现这个状况）
<img width="333" height="337" alt="download" src="https://github.com/user-attachments/assets/28a86788-3f17-42a6-81bb-ed10dc11b589" />
