### PR TITLE
[构建] CI 换用 macos-26 + Xcode 26.6 修复图标编译崩溃

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   build-and-release:
-    runs-on: macos-15
+    # macos-26 镜像自带 Xcode 26.6。macos-15 镜像最高只到 26.3,其 ibtoold 编译
+    # Icon Composer 图标包(AppIcon.icon)必崩(CompileAssetCatalogVariant 失败),
+    # 26.6 已修复,与本地构建环境一致。
+    runs-on: macos-26
     permissions:
       contents: write
     env:
@@ -16,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.3.app/Contents/Developer
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
 
       - name: Import signing certificate
         env:


### PR DESCRIPTION
macos-15 镜像最高 Xcode 26.3，其 ibtoold 编译 v1.1.4 新增的 AppIcon.icon（Icon Composer 包）必崩（3 次 CI 全部失败于 CompileAssetCatalogVariant）。本地 Xcode 26.6 编译正常。换用 macos-26 镜像 + Xcode 26.6，与本地环境一致。