### PR TITLE
修复 M4 机型充电功率无法显示

### DIFF
--- a/HagimiMonitor/Samplers/BatterySampler.swift
+++ b/HagimiMonitor/Samplers/BatterySampler.swift
@@ -32,7 +32,7 @@ final class BatterySampler: MonitorSampler {
         let sourceState = description[kIOPSPowerSourceStateKey] as? String
         let connected = sourceState == kIOPSACPowerValue
 
-        let smart = smartBatteryInfo()
+        let smart = smartBatteryInfo(isCharging: isCharging)
         let adapterWatts = smart.adapterWatts ?? externalAdapterWatts()
         let chargingPower = connected
             ? (smart.telemetryChargingWatts ?? smart.chargingPowerWatts)
@@ -74,7 +74,7 @@ final class BatterySampler: MonitorSampler {
         )
     }
 
-    private func smartBatteryInfo() -> SmartBatteryInfo {
+    private func smartBatteryInfo(isCharging: Bool) -> SmartBatteryInfo {
         let service = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("AppleSmartBattery"))
         guard service != IO_OBJECT_NULL else {
             return SmartBatteryInfo()
@@ -110,8 +110,8 @@ final class BatterySampler: MonitorSampler {
         let amperage = lookupDouble("Amperage")
         let adapterWatts = adapterWatts(service)
         let systemPowerWatts = systemPowerWatts(service)
-        let chargingPowerWatts = chargingPowerWatts(service)
-        let telemetryChargingWatts = telemetryChargingWatts(service)
+        let chargingPowerWatts = chargingPowerWatts(service, isCharging: isCharging)
+        let telemetryChargingWatts = telemetryChargingWatts(service, isCharging: isCharging)
         let temperature = lookupDouble("Temperature").map { $0 / 100 }
         let health = if let maxCapacity, let designCapacity, designCapacity > 0 {
             min(100, max(0, maxCapacity / designCapacity * 100))
@@ -151,16 +151,22 @@ final class BatterySampler: MonitorSampler {
         return doubleValue(details[kIOPSPowerAdapterWattsKey])
     }
 
-    private func chargingPowerWatts(_ service: io_service_t) -> Double? {
-        // 优先用 PowerTelemetryData.BatteryPower（电池包级别，准确）
+    private func chargingPowerWatts(_ service: io_service_t, isCharging: Bool) -> Double? {
+        // 优先用 PowerTelemetryData.BatteryPower（电池包级别，准确）。
+        // BatteryPower 的符号在不同硬件 / macOS 版本上并不一致，
+        // 因此用 IOPS 的充电状态判断方向，只把绝对值当作充电功率。
         if let value = IORegistryEntryCreateCFProperty(service, "PowerTelemetryData" as CFString, kCFAllocatorDefault, 0)?
             .takeRetainedValue() as? [String: Any],
-           let bp = signedDoubleValue(value["BatteryPower"]), bp < 0 {
-            return abs(bp) / 1_000
+           let watts = interpretedChargingPowerWatts(
+               batteryPowerMilliwatts: signedDoubleValue(value["BatteryPower"]),
+               isCharging: isCharging
+           ) {
+            return watts
         }
         // Fallback: ChargerData 的 ChargingCurrent * ChargingVoltage
         // 注意 ChargingVoltage 是单节电芯电压，结果会偏低
-        guard let value = IORegistryEntryCreateCFProperty(service, "ChargerData" as CFString, kCFAllocatorDefault, 0)?
+        guard isCharging,
+              let value = IORegistryEntryCreateCFProperty(service, "ChargerData" as CFString, kCFAllocatorDefault, 0)?
             .takeRetainedValue() as? [String: Any],
               let current = doubleValue(value["ChargingCurrent"]),
               let voltage = doubleValue(value["ChargingVoltage"]) else {
@@ -169,13 +175,15 @@ final class BatterySampler: MonitorSampler {
         return nonZeroWatts(current * voltage / 1_000_000)
     }
 
-    private func telemetryChargingWatts(_ service: io_service_t) -> Double? {
+    private func telemetryChargingWatts(_ service: io_service_t, isCharging: Bool) -> Double? {
         guard let value = IORegistryEntryCreateCFProperty(service, "PowerTelemetryData" as CFString, kCFAllocatorDefault, 0)?
-            .takeRetainedValue() as? [String: Any],
-              let bp = signedDoubleValue(value["BatteryPower"]), bp < 0 else {
+            .takeRetainedValue() as? [String: Any] else {
             return nil
         }
-        return abs(bp) / 1_000
+        return interpretedChargingPowerWatts(
+            batteryPowerMilliwatts: signedDoubleValue(value["BatteryPower"]),
+            isCharging: isCharging
+        )
     }
 
     private func powerTelemetryWatts() -> Double? {

--- a/HagimiMonitor/Samplers/Utils.swift
+++ b/HagimiMonitor/Samplers/Utils.swift
@@ -54,6 +54,13 @@ func nonZeroWatts(_ value: Double?) -> Double? {
     return value
 }
 
+func interpretedChargingPowerWatts(batteryPowerMilliwatts: Double?, isCharging: Bool) -> Double? {
+    guard isCharging, let batteryPowerMilliwatts else {
+        return nil
+    }
+    return nonZeroWatts(abs(batteryPowerMilliwatts) / 1_000)
+}
+
 private let byteFormatter: ByteCountFormatter = {
     let formatter = ByteCountFormatter()
     formatter.allowedUnits = [.useGB, .useMB]

--- a/HagimiMonitorTests/BatterySamplerTests.swift
+++ b/HagimiMonitorTests/BatterySamplerTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import HagimiMonitor
+
+struct BatterySamplerTests {
+    @Test func chargingPowerAcceptsPositiveTelemetryOnM4() {
+        let watts = interpretedChargingPowerWatts(
+            batteryPowerMilliwatts: 24_898,
+            isCharging: true
+        )
+
+        #expect(watts.map { abs($0 - 24.898) < 0.000_001 } == true)
+    }
+
+    @Test func chargingPowerKeepsSupportingNegativeTelemetry() {
+        let watts = interpretedChargingPowerWatts(
+            batteryPowerMilliwatts: -24_898,
+            isCharging: true
+        )
+
+        #expect(watts.map { abs($0 - 24.898) < 0.000_001 } == true)
+    }
+
+    @Test func chargingPowerIgnoresTelemetryWhenNotCharging() {
+        #expect(interpretedChargingPowerWatts(batteryPowerMilliwatts: 24_898, isCharging: false) == nil)
+        #expect(interpretedChargingPowerWatts(batteryPowerMilliwatts: -24_898, isCharging: false) == nil)
+    }
+
+    @Test func chargingPowerTreatsZeroAsUnavailable() {
+        #expect(interpretedChargingPowerWatts(batteryPowerMilliwatts: 0, isCharging: true) == nil)
+    }
+}


### PR DESCRIPTION
## 问题

在 MacBook Air M4 / macOS 27 上，`PowerTelemetryData.BatteryPower` 在充电时返回正值。现有实现只接受负值，因此有效的充电功率被丢弃并显示为 `--`。

实机采样数据：

- `IsCharging = true`
- `BatteryPower = 24898 mW`
- `SystemPowerIn = 46441 mW`
- `SystemLoad = 21543 mW`

其中 `46441 - 24898 = 21543`，可确认 `BatteryPower` 的正值代表流入电池的功率。

## 修改

- 使用 IOPS 的 `isCharging` 状态判断功率方向。
- 充电时兼容 `BatteryPower` 的正、负两种符号，并显示其绝对值。
- 非充电状态不把遥测值误报为充电功率。
- ChargerData 回退路径也受充电状态保护。
- 添加正值、负值、非充电和零值回归测试。

## 验证

- Swift 语法检查通过。
- 核心转换逻辑独立运行测试通过。
- 当前环境没有完整 Xcode，未执行完整 `xcodebuild test`。

Closes #86
